### PR TITLE
Ignore hosts that are empty string

### DIFF
--- a/dnsblackhole/__init__.py
+++ b/dnsblackhole/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info[0] == 2:
     sys.setdefaultencoding('utf-8')
 
 # Default variables
-                        
+
 DEFAULT_CONFIG_PATHS = ['{0}/.dns-blackhole.yml'.format(os.getenv("HOME")),
                         '/etc/dns-blackhole/dns-blackhole.yml',
                         './dns-blackhole.yml'
@@ -147,6 +147,10 @@ def process_host_file_url(bh_list, white_list, zone_data, host_file_urls):
                     if n_host == 'localhost.localdomain' or n_host == 'localhost':
                         continue
 
+                    # Ignore empty string
+                    if n_host == '':
+                        continue
+
                     # Now add the hosts to the list
                     if n_host not in white_list:
                         bh_list.append(zone_data.format(**{'domain': n_host}))
@@ -208,6 +212,10 @@ def process_easylist_url(bh_list, white_list, zone_data, easy_list_url):
                     # Some put caps
                     n_host = n_host.lower()
 
+                    # ignore empty string
+                    if n_host == '':
+                        continue
+
                     # Now add the hosts to the list
                     if n_host not in white_list:
                         bh_list.append(zone_data.format(**{'domain': n_host}))
@@ -242,6 +250,8 @@ def process_disconnect_url(bh_list, white_list, zone_data, d_url, d_cat):
                             h_list = sub_dict[entity][main_url]
                             if isinstance(h_list, list):
                                 for host in h_list:
+                                    if host == '':
+                                        continue
                                     if host not in white_list:
                                         bh_list.append(zone_data.format(**{'domain': host}))
     else:


### PR DESCRIPTION
Most recent download of hosts file resulted in an error when restarting unbound:
```
unbound-checkconf[23518]: [1505573446] unbound-checkconf[23518:0] error: cannot parse name
unbound-checkconf[23518]: [1505573446] unbound-checkconf[23518:0] error: bad zone name  always_nxdomain
unbound-checkconf[23518]: [1505573446] unbound-checkconf[23518:0] fatal error: failed local-zone, local-data configuration
systemd[1]: unbound.service: Control process exited, code=exited status=1
systemd[1]: Failed to start Unbound recursive Domain Name Server.
```
The issue was the first entry in my `blacklist.zone` file was:
```
local-zone: "" always_nxdomain
```
Once I removed that entry unbound was able to start again fine. This PR ensures that no empty string hosts are added to the `blacklist.zone` file