### PR TITLE
Fix YAML loading -- newer versions of pyYAML either require a `Loader` arg or use of `safe_load()`

### DIFF
--- a/dnsblackhole/__init__.py
+++ b/dnsblackhole/__init__.py
@@ -46,7 +46,7 @@ def load_config():
             sys.exit()
 
         try:
-            yaml_config = yaml.load(f)
+            yaml_config = yaml.safe_load(f)
         except yaml.YAMLError as exc:
             print("Error in configuration file: {0}".format(exc))
 


### PR DESCRIPTION
Fix YAML loading

```
Traceback (most recent call last):
  File "/usr/local/bin/dns-blackhole", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/local/lib/python3.13/site-packages/dnsblackhole/cli.py", line 4, in main
    dnsblackhole.main()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/dnsblackhole/__init__.py", line 326, in main
    config = load_config()
  File "/usr/local/lib/python3.13/site-packages/dnsblackhole/__init__.py", line 49, in load_config
    yaml_config = yaml.load(f)
TypeError: load() missing 1 required positional argument: 'Loader'
```